### PR TITLE
Add Jupyter to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ sklearn = "*"
 joblib = "*"
 flask = "*"
 pytest = "*"
+jupyter = "*"
 
 [dev-packages]
 pandas = "*"


### PR DESCRIPTION
Running `pipenv jupyter notebook` didn't work, but adding `jupyter = "*"` fixes this.