### PR TITLE
Update endpoints and tests based on new model

### DIFF
--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -39,7 +39,7 @@ def configure_routes(app):
                 result['internet_int'] = applicant['internet_int']
                 result['higher_int'] = applicant['higher_int']
                 result['paid_int'] = applicant['paid_int']
-                result['studytime'] = applicant['hestudytimealth']
+                result['studytime'] = applicant['studytime']
                 result['address_int'] = applicant['address_int']
                 attributes.append(result)
                 return jsonify(attributes[-1]), 200
@@ -65,4 +65,4 @@ def configure_routes(app):
         })
         query = pd.get_dummies(query_df)
         prediction = clf.predict(query)
-        return jsonify(np.ndarray.item(prediction))
+        return jsonify(np.ndarray.item(prediction)), 200

--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -15,17 +15,53 @@ def configure_routes(app):
     def hello():
         return "try the predict route it is great!"
 
-    @app.route('/predict')
+    attributes = [
+        { 'health': 0, 'absences': 0, 'age': 0, 'failures': 0, 'Dalc': 0, 'internet_int': 0, 
+          'higher_int': 0, 'paid_int': 0, 'studytime': 0, 'address_int': 0 }
+    ]
+
+    @app.route('/applicants', methods=['GET', 'POST'])
+    def applicants():
+        if request.method == "GET":
+            return jsonify(attributes[-1]), 200
+        if request.method == "POST":
+            result = {}
+            applicant = request.get_json()
+            if ('health' in applicant and 'absences' in applicant and 'age' in applicant 
+            and 'failures' in applicant and 'Dalc' in applicant and 'internet_int' in applicant 
+            and 'higher_int' in applicant and 'paid_int' in applicant and 'studytime' in applicant
+            and 'address_int' in applicant):
+                result['health'] = applicant['health']
+                result['absences'] = applicant['absences']
+                result['age'] = applicant['age']
+                result['failures'] = applicant['failures']
+                result['Dalc'] = applicant['Dalc']
+                result['internet_int'] = applicant['internet_int']
+                result['higher_int'] = applicant['higher_int']
+                result['paid_int'] = applicant['paid_int']
+                result['studytime'] = applicant['hestudytimealth']
+                result['address_int'] = applicant['address_int']
+                attributes.append(result)
+                return "Successfully added new applicant attributes: " + jsonify(attributes[-1]), 200
+            else:
+                return "Invalid input: dictionary should contain 'health', 'absences', 'age', 'failures', \
+                    'Dalc', 'internet_int', 'higher_int', 'paid_int', 'studytime', and 'address_int' attributes.", 400
+
+
+    @app.route('/predict', methods=['GET'])
     def predict():
         #use entries from the query string here but could also use json
-        age = request.args.get('age')
-        absences = request.args.get('absences')
-        health = request.args.get('health')
-        data = [[age], [health], [absences]]
         query_df = pd.DataFrame({
-            'age': pd.Series(age),
-            'health': pd.Series(health),
-            'absences': pd.Series(absences)
+            'health': pd.Series(request.args.get('health')),
+            'absences': pd.Series(request.args.get('absences')),
+            'age': pd.Series(request.args.get('age')),
+            'failures': pd.Series(request.args.get('failures')),
+            'Dalc': pd.Series(request.args.get('Dalc')),
+            'internet_int': pd.Series(request.args.get('internet_int')),
+            'higher_int': pd.Series(request.args.get('higher_int')),
+            'paid_int': pd.Series(request.args.get('paid_int')),
+            'studytime': pd.Series(request.args.get('studytime')),
+            'address_int': pd.Series(request.args.get('address_int'))
         })
         query = pd.get_dummies(query_df)
         prediction = clf.predict(query)

--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -52,16 +52,16 @@ def configure_routes(app):
     def predict():
         #use entries from the query string here but could also use json
         query_df = pd.DataFrame({
-            'health': pd.Series(request.args.get('health')),
-            'absences': pd.Series(request.args.get('absences')),
-            'age': pd.Series(request.args.get('age')),
-            'failures': pd.Series(request.args.get('failures')),
-            'Dalc': pd.Series(request.args.get('Dalc')),
-            'internet_int': pd.Series(request.args.get('internet_int')),
-            'higher_int': pd.Series(request.args.get('higher_int')),
-            'paid_int': pd.Series(request.args.get('paid_int')),
-            'studytime': pd.Series(request.args.get('studytime')),
-            'address_int': pd.Series(request.args.get('address_int'))
+            'health': pd.Series(attributes[-1]['health']),
+            'absences': pd.Series(attributes[-1]['absences']),
+            'age': pd.Series(attributes[-1]['age']),
+            'failures': pd.Series(attributes[-1]['failures']),
+            'Dalc': pd.Series(attributes[-1]['Dalc']),
+            'internet_int': pd.Series(attributes[-1]['internet_int']),
+            'higher_int': pd.Series(attributes[-1]['higher_int']),
+            'paid_int': pd.Series(attributes[-1]['paid_int']),
+            'studytime': pd.Series(attributes[-1]['studytime']),
+            'address_int': pd.Series(attributes[-1]['address_int'])
         })
         query = pd.get_dummies(query_df)
         prediction = clf.predict(query)

--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -42,7 +42,7 @@ def configure_routes(app):
                 result['studytime'] = applicant['hestudytimealth']
                 result['address_int'] = applicant['address_int']
                 attributes.append(result)
-                return "Successfully added new applicant attributes: " + jsonify(attributes[-1]), 200
+                return jsonify(attributes[-1]), 200
             else:
                 return "Invalid input: dictionary should contain 'health', 'absences', 'age', 'failures', \
                     'Dalc', 'internet_int', 'higher_int', 'paid_int', 'studytime', and 'address_int' attributes.", 400

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -24,7 +24,8 @@ def test_get_applicants_route_request_without_post():
 
     assert response.status_code == 200
     # Should return default with all attribute values = 0
-    assert response.get_data() == b"Successfully added new applicant attributes: "
+    assert response.get_data() == b'{"Dalc":0,"absences":0,"address_int":0,"age":0,"failures":0,"health":0,"high' 
+    +  b'er_int":0,"internet_int":0,"paid_int":0,"studytime":0}\n'
 
 
 def test_post_applicants_route_invalid_format():
@@ -35,9 +36,7 @@ def test_post_applicants_route_invalid_format():
 
     response = client.post(url, json=100)
 
-    assert response.status_code == 400 # Not all attributes found
-    assert response.get_data() == b"Invalid input: dictionary should contain 'health', 'absences', 'age', 'failures', \
-                    'Dalc', 'internet_int', 'higher_int', 'paid_int', 'studytime', and 'address_int' attributes."
+    assert response.status_code == 500 # Internal server error: 100 is not iterable
 
 def test_post_applicants_route_invalid_input():
     app = Flask(__name__)

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -62,22 +62,26 @@ def test_predict_route_without_post():
     response = client.get(url)
 
     assert response.status_code == 200
-    assert response.get_data() == 0
+    assert response.get_data() == b'0\n'
 
 
-def test_get_applicants_route():
+def test_post_and_get_applicants_route():
     app = Flask(__name__)
     configure_routes(app)
     client = app.test_client()
+    url = '/applicants'
 
     # when I post to /applicants, I should be able to get that data back
-    response = client.post('/applicants', json={
+    response = client.post(url, json={
         'age': 16, 'absences': 3, 'health': 95, 'failures': 0, 'Dalc': 0, 'internet_int': 1, 
         'higher_int': 1, 'paid_int': 1, 'studytime': 1, 'address_int': 0
     })
     assert response.status_code == 200
-    assert response.get_data() == { 'age': 16, 'absences': 3, 'health': 95, 'failures': 0, 'Dalc': 0,
-        'internet_int': 1, 'higher_int': 1, 'paid_int': 1, 'studytime': 1, 'address_int': 0 }
+    assert response.get_data() == b'{"Dalc":0,"absences":3,"address_int":0,"age":16,"failures":0,"health":95,"higher_int":1,"internet_int":1,"paid_int":1,"studytime":1}\n'
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.get_data() == b'{"Dalc":0,"absences":3,"address_int":0,"age":16,"failures":0,"health":95,"higher_int":1,"internet_int":1,"paid_int":1,"studytime":1}\n'
     
     
 def test_get_predict_route():
@@ -95,7 +99,7 @@ def test_get_predict_route():
     response = client.get('/predict')
 
     assert response.status_code == 200
-    assert response.get_data() == 1 or response.get_data() == 0
+    assert response.get_data() == b'1\n' or response.get_data() == b'0\n'
     
 def test_undefined_route():
     app = Flask(__name__)

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -14,6 +14,19 @@ def test_base_route():
     assert response.status_code == 200
     assert response.get_data() == b'try the predict route it is great!'
 
+def test_get_applicants_route_request_without_post():
+    app = Flask(__name__)
+    configure_routes(app)
+    client = app.test_client()
+    url = '/applicants'
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+    # Should return default with all attribute values = 0
+    assert response.get_data() == b"Successfully added new applicant attributes: "
+
+
 def test_post_applicants_route_invalid_format():
     app = Flask(__name__)
     configure_routes(app)
@@ -22,19 +35,9 @@ def test_post_applicants_route_invalid_format():
 
     response = client.post(url, json=100)
 
-    assert response.status_code == 404 # Not found: age, absences, and health attributes
-
-
-def test_get_applicants_route_invalid_request():
-    app = Flask(__name__)
-    configure_routes(app)
-    client = app.test_client()
-    url = '/applicants'
-
-    response = client.get(url)
-
-    assert response.status_code == 404 # Not found: age, absences, and health attributes
-
+    assert response.status_code == 400 # Not all attributes found
+    assert response.get_data() == b"Invalid input: dictionary should contain 'health', 'absences', 'age', 'failures', \
+                    'Dalc', 'internet_int', 'higher_int', 'paid_int', 'studytime', and 'address_int' attributes."
 
 def test_post_applicants_route_invalid_input():
     app = Flask(__name__)
@@ -43,13 +46,16 @@ def test_post_applicants_route_invalid_input():
     url = '/applicants'
 
     response = client.post(url, json={
-        'age': 16, 'absences': 3
+        'age': 16, 'absences': 3, 'failures': 0, 'Dalc': 0, 'internet_int': 0, 
+        'higher_int': 0, 'paid_int': 0, 'studytime': 0, 'address_int': 0
     })
 
-    assert response.status_code == 404 # Not found: health attribute
+    assert response.status_code == 400 # Not all attributes found (health)
+    assert response.get_data() == b"Invalid input: dictionary should contain 'health', 'absences', 'age', 'failures', \
+                    'Dalc', 'internet_int', 'higher_int', 'paid_int', 'studytime', and 'address_int' attributes."
 
 
-def test_predict_route_invalid_request():
+def test_predict_route_without_post():
     app = Flask(__name__)
     configure_routes(app)
     client = app.test_client()
@@ -57,8 +63,10 @@ def test_predict_route_invalid_request():
 
     response = client.get(url)
 
-    assert response.status_code == 500 # Internal server error: nothing was posted
-    
+    assert response.status_code == 200
+    assert response.get_data() == 0
+
+
 def test_get_applicants_route():
     app = Flask(__name__)
     configure_routes(app)
@@ -66,10 +74,12 @@ def test_get_applicants_route():
 
     # when I post to /applicants, I should be able to get that data back
     response = client.post('/applicants', json={
-        'age': 16, 'absences': 3, 'health': 95
+        'age': 16, 'absences': 3, 'health': 95, 'failures': 0, 'Dalc': 0, 'internet_int': 1, 
+        'higher_int': 1, 'paid_int': 1, 'studytime': 1, 'address_int': 0
     })
     assert response.status_code == 200
-    assert response.get_data() == { 'age': 16, 'absences': 3, 'health': 95 }
+    assert response.get_data() == { 'age': 16, 'absences': 3, 'health': 95, 'failures': 0, 'Dalc': 0,
+        'internet_int': 1, 'higher_int': 1, 'paid_int': 1, 'studytime': 1, 'address_int': 0 }
     
     
 def test_get_predict_route():
@@ -80,7 +90,8 @@ def test_get_predict_route():
     # when I post to client via the applicant endpoint, 
     # I should get the model prediction from the predict endpoint
     client.post('/applicants', json={
-        'age': 16, 'absences': 3, 'health': 95
+        'age': 16, 'absences': 3, 'health': 95, 'failures': 0, 'Dalc': 0, 'internet_int': 1, 
+        'higher_int': 1, 'paid_int': 1, 'studytime': 1, 'address_int': 0
     })
     
     response = client.get('/predict')

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -24,8 +24,7 @@ def test_get_applicants_route_request_without_post():
 
     assert response.status_code == 200
     # Should return default with all attribute values = 0
-    assert response.get_data() == b'{"Dalc":0,"absences":0,"address_int":0,"age":0,"failures":0,"health":0,"high' 
-    +  b'er_int":0,"internet_int":0,"paid_int":0,"studytime":0}\n'
+    assert response.get_data() == b'{"Dalc":0,"absences":0,"address_int":0,"age":0,"failures":0,"health":0,"higher_int":0,"internet_int":0,"paid_int":0,"studytime":0}\n'
 
 
 def test_post_applicants_route_invalid_format():


### PR DESCRIPTION
Add all the new attributes to the `/applicants` and `/predict` routes, and update the tests based on their new functionalities